### PR TITLE
Fix a race condition in event_responder

### DIFF
--- a/colmena/thinker/__init__.py
+++ b/colmena/thinker/__init__.py
@@ -113,14 +113,10 @@ def _event_responder_agent(thinker: 'BaseThinker', process_func: Callable, event
     reallocator_thread: Optional[ReallocatorThread] = None
     while not thinker.done.is_set():
         if event.wait(_DONE_REACTION_TIME):
-            # Create a "function is done" event
-            func_is_done = Event()
-
             # If desired, launch the resource-allocation thread
             if reallocate_resources:
                 reallocator_thread = ReallocatorThread(
-                    thinker.rec, func_is_done,
-                    gather_from=gather_from, gather_to=gather_to,
+                    thinker.rec, gather_from=gather_from, gather_to=gather_to,
                     disperse_to=disperse_to, max_slots=max_slots,
                     slot_step=slot_step, logger_name=thinker.logger.name + ".allocate"
                 )
@@ -129,11 +125,9 @@ def _event_responder_agent(thinker: 'BaseThinker', process_func: Callable, event
             # Launch the function
             process_func(thinker)
 
-            # When complete, set the Event flag (killing the resource allocator)
-            func_is_done.set()
-
-            # Wait for the resource allocator to die
+            # If we are using resource re-allocation, set the stop condition and wait for resources to be freed
             if reallocator_thread is not None:
+                reallocator_thread.stop_event.set()
                 reallocator_thread.join()
 
 

--- a/colmena/thinker/__init__.py
+++ b/colmena/thinker/__init__.py
@@ -110,12 +110,11 @@ def _event_responder_agent(thinker: 'BaseThinker', process_func: Callable, event
         max_slots = getattr(thinker, max_slots)
 
     # Loop until the thinker is completed
-    func_is_done = Event()
     reallocator_thread: Optional[ReallocatorThread] = None
     while not thinker.done.is_set():
         if event.wait(_DONE_REACTION_TIME):
-            # Reset the "function is done" event
-            func_is_done.clear()
+            # Create a "function is done" event
+            func_is_done = Event()
 
             # If desired, launch the resource-allocation thread
             if reallocate_resources:

--- a/colmena/thinker/resources.py
+++ b/colmena/thinker/resources.py
@@ -254,7 +254,8 @@ class ReallocatorThread(Thread):
         self.logger = logger if logger_name is None else logging.getLogger(logger_name)
 
     def run(self) -> None:
-        self.logger.info('Starting resource allocation thread')
+        self.logger.info(f'Starting resource allocation thread. Allocating a maximum of {self.max_slots} to {self.gather_to} from'
+                         f' {self.gather_from} in steps of {self.slot_step}')
 
         # Acquire resources until either the maximum is reached, or the event is triggered
         while (self.max_slots is None or self.resource_counter.allocated_slots(self.gather_to) < self.max_slots) \

--- a/colmena/thinker/tests/test_resources.py
+++ b/colmena/thinker/tests/test_resources.py
@@ -63,6 +63,10 @@ def test_allocations(rec):
     assert rec.available_slots("sim") == 4
     assert stop.is_set()
 
+    # Test out reallocate all
+    rec.reallocate("sim", "ml", "all")
+    assert rec.allocated_slots("sim") == 0
+    assert rec.allocated_slots("ml") == 8
 
 def test_reallocator(rec):
     # Start with everything allocated to "simulation"

--- a/colmena/thinker/tests/test_resources.py
+++ b/colmena/thinker/tests/test_resources.py
@@ -98,6 +98,7 @@ def test_reallocator(rec):
 
 
 @mark.timeout(2)
+@mark.repeat(4)
 def test_reallocator_deadlock(rec):
     """Creates the deadlock reported in https://github.com/exalearn/colmena/issues/43"""
     rec.reallocate(None, "sim", 8)

--- a/colmena/thinker/tests/test_resources.py
+++ b/colmena/thinker/tests/test_resources.py
@@ -68,6 +68,7 @@ def test_allocations(rec):
     assert rec.allocated_slots("sim") == 0
     assert rec.allocated_slots("ml") == 8
 
+
 def test_reallocator(rec):
     # Start with everything allocated to "simulation"
     rec.reallocate(None, "sim", 8)

--- a/colmena/thinker/tests/test_resources.py
+++ b/colmena/thinker/tests/test_resources.py
@@ -1,7 +1,7 @@
 from threading import Timer, Event
 from time import sleep
 
-from pytest import fixture
+from pytest import fixture, mark
 
 from colmena.thinker.resources import ResourceCounter, ReallocatorThread
 
@@ -70,7 +70,7 @@ def test_reallocator(rec):
 
     # Test allocating up to the maximum
     stop = Event()
-    alloc = ReallocatorThread(rec, stop, gather_from="sim", gather_to="ml", disperse_to=None, max_slots=2)
+    alloc = ReallocatorThread(rec, stop_event=stop, gather_from="sim", gather_to="ml", disperse_to=None, max_slots=2)
     alloc.start()
     sleep(0.2)
     assert alloc.is_alive()
@@ -84,7 +84,7 @@ def test_reallocator(rec):
 
     # Test without a maximum allocation
     stop.clear()
-    alloc = ReallocatorThread(rec, stop, gather_from="sim", gather_to="ml", disperse_to=None)
+    alloc = ReallocatorThread(rec, stop_event=stop, gather_from="sim", gather_to="ml", disperse_to=None)
     alloc.start()
     sleep(0.2)
     assert alloc.is_alive()
@@ -95,3 +95,32 @@ def test_reallocator(rec):
     sleep(2)  # We check for the flag every 1s
     assert not alloc.is_alive()
     assert rec.unallocated_slots == 8
+
+
+@mark.timeout(2)
+def test_reallocator_deadlock(rec):
+    """Creates the deadlock reported in https://github.com/exalearn/colmena/issues/43"""
+    rec.reallocate(None, "sim", 8)
+    assert rec.available_slots("sim") == 8
+
+    # Create two allocators: One that pulls from sim and another that pulls from ml
+    ml_alloc = ReallocatorThread(rec, gather_from="sim", gather_to="ml", disperse_to="sim", max_slots=8)
+    sim_alloc = ReallocatorThread(rec, gather_from="ml", gather_to="sim", disperse_to="ml", max_slots=8)
+
+    # Start the ML allocator, which will pull resources from sim to ml
+    ml_alloc.start()
+    assert not ml_alloc.stop_event.is_set()
+    assert rec.available_slots("ml") == 8
+    assert rec.acquire("ml", 8)
+    assert rec.available_slots("ml") == 0
+
+    # Start the sim allocator, which will ask to pull resources from ml over to sim
+    sim_alloc.start()
+    sleep(0.001)
+    assert rec.available_slots("ml") == 0
+
+    # Send the stop signal and wait for ml_alloc to exit
+    ml_alloc.stop_event.set()
+    rec.release("ml", 8)
+    ml_alloc.join(1)
+    assert not ml_alloc.is_alive()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ flake8
 pytest
 pytest-timeout
 pytest-mock
+pytest-repeat


### PR DESCRIPTION
There is a chance that the resource allocator thread will not exit before the next one is create, which leads to some resource
contention. Fixed by creating a new event for each iteration

Fixes #43 