### PR TITLE
Simplify Parsl task server

### DIFF
--- a/colmena/task_server/base.py
+++ b/colmena/task_server/base.py
@@ -1,8 +1,9 @@
-"""Base class for the Task Server"""
+"""Base classes for the Task Server and associated functions"""
 import os
 import platform
 
 from abc import ABCMeta, abstractmethod
+from concurrent.futures import Future
 from multiprocessing import Process
 from time import perf_counter
 from typing import Optional, Callable
@@ -17,20 +18,23 @@ logger = logging.getLogger(__name__)
 
 
 class BaseTaskServer(Process, metaclass=ABCMeta):
-    """Abstract class for the Colmena Task Server, which manages the execution
-    of different asks
+    """Abstract class for the Colmena Task Server, which manages the execution of tasks
 
-    Clients submit task requests to the server by pushing them to a Redis queue,
-    and then receive results from a second queue.
+    Start the task server by first instantiating it and then calling :meth:`start` to launch the server in a separate process.
+    Clients submit task requests to the server by pushing them to a Redis queue, and then receive results from a second queue.
+
+    The task server can be stopped by pushing a ``None`` to the task queue, signaling that no new tasks will be incoming.
+    The remaining tasks will continue to be pushed to the output queue.
+
+    ## Implementing a Task Server
 
     Different implementations vary in how the queue is processed.
 
-    Start the task server by first instantiating it and then calling :meth:`start`
-    to launch the server in a separate process.
+    Each implementation must provide the :meth:`process_queue` function is responsible for executing tasks supplied on the tasks queue
+    and ensuring completed results are written back to the result queue on completion.
+    Tasks must first be wrapped in the :meth:`run_and_record_timing` decorator function to capture the runtime information.
 
-    The task server can be stopped by pushing a ``None`` to the task queue,
-    signaling that no new tasks will be incoming. The remaining tasks will
-    continue to be pushed to the output queue.
+    Implementations should also provide a `_cleanup` function that releases any resources reserved by the task server.
     """
 
     def __init__(self, queues: TaskServerQueues, timeout: Optional[int] = None):
@@ -44,15 +48,25 @@ class BaseTaskServer(Process, metaclass=ABCMeta):
         self.timeout = timeout
 
     @abstractmethod
-    def process_queue(self):
-        """Evaluate a single task from the queue"""
+    def process_queue(self, topic: str, task: Result):
+        """Execute a single task from the task queue
+
+        Args:
+            topic: Which task queue this result came from
+            task: Task description
+        """
         pass
 
     def listen_and_launch(self):
         logger.info('Begin pulling from task queue')
         while True:
+            # Get a result from the queue
+            topic, task = self.queues.get_task(self.timeout)
+            logger.info(f'Received request for {task.method} with topic {topic}')
+
+            # Provide it to the workflow system to be executed
             try:
-                self.process_queue()
+                self.process_queue(topic, task)
             except KillSignalException:
                 logger.info('Kill signal received')
                 return
@@ -60,7 +74,6 @@ class BaseTaskServer(Process, metaclass=ABCMeta):
                 logger.info('Timeout while waiting on task queue')
                 return
 
-    @abstractmethod
     def _cleanup(self):
         """Close out any resources needed by the task server"""
         pass
@@ -76,6 +89,57 @@ class BaseTaskServer(Process, metaclass=ABCMeta):
 
         # Shutdown any needed functions
         self._cleanup()
+
+
+class FutureBasedTaskServer(BaseTaskServer, metaclass=ABCMeta):
+    """Base class for workflow engines that use Python's native Future object
+
+    Implementations need to specify a function, :meth:`_submit`, that creates the Future and
+    `FutureBasedTaskServer`'s implementation of :meth:`process_queue` will add a
+    callback to submit the output to the result queue.
+    Note that implementations are still responsible for adding the :meth:`run_and_record_timing` decorator.
+    """
+
+    def _perform_callback(self, future: Future, result: Result, topic: str):
+        """Send a completed result back to queue. Used as a callback for complete tasks
+
+        Args:
+            future: Future created by FuncX
+            result: Initial result object. Used if the future throws an exception
+            topic: Topic used to send back to the user
+        """
+
+        task_exc = future.exception()
+
+        # If it was, send back a modified copy of the input structure
+        if future.exception() is not None:
+            # Mark it as unsuccessful and capture the exception information
+            result.success = False
+            result.failure_info = FailureInformation.from_exception(task_exc)
+        else:
+            # If not, the result object is the one we need
+            result = future.result()
+
+        # Put them back in the pipe with the proper topic
+        self.queues.send_result(result, topic)
+
+    @abstractmethod
+    def _submit(self, task: Result) -> Future:
+        """Submit the task to the workflow engine
+
+        Args:
+            task: Task description
+        Returns:
+            Future for the result object
+        """
+        pass
+
+    def process_queue(self, topic: str, task: Result):
+        # Launch the task
+        future = self._submit(task)
+
+        # Create the callback
+        future.add_done_callback(lambda x: self._perform_callback(x, task, topic))
 
 
 def run_and_record_timing(func: Callable, result: Result) -> Result:

--- a/colmena/task_server/tests/test_parsl.py
+++ b/colmena/task_server/tests/test_parsl.py
@@ -47,7 +47,7 @@ def test_kill(server_and_queue):
 
     # Make sure it throws the correct exception
     with raises(KillSignalException):
-        server.process_queue()
+        server.listen_and_launch()
 
     # Make sure it kills the server
     queue.send_kill_signal()
@@ -83,7 +83,7 @@ def test_timeout(server_and_queue):
 
     # Make sure it throws the correct exception
     with raises(TimeoutException):
-        server.process_queue()
+        server.listen_and_launch()
 
     # Make sure it kills the server
     server.start()


### PR DESCRIPTION
Uses the "add_callback" function of Python futures to send tasks back to the Redis queue rather than a combination of PythonApp's executed using Parsl and an "error scavenger" thread.

While at it, I created another base class that provides the callback functionality now used by both Parsl and FuncX task servers.