### PR TITLE
ProxyStore Improvements

### DIFF
--- a/colmena/models.py
+++ b/colmena/models.py
@@ -10,8 +10,9 @@ from typing import Any, Tuple, Dict, Optional, Union
 
 from pydantic import BaseModel, Field
 
-import colmena
 import proxystore as ps
+
+from colmena.proxy import proxy_json_encoder
 
 logger = logging.getLogger(__name__)
 
@@ -114,11 +115,8 @@ class Result(BaseModel):
                                                       description="Method used to serialize input data")
     keep_inputs: bool = Field(True, description="Whether to keep the inputs with the result object or delete "
                                                 "them after the method has completed")
-    value_server_hostname: Optional[str] = Field(None, description="Value server hostname")
-    value_server_port: Optional[str] = Field(None, description="Value server port")
-    value_server_threshold: int = Field(
-        None, description="Object size threshold (bytes) at which input/value "
-                          "objects are stored in value server before serialization")
+    proxystore_name: Optional[str] = Field(None, description="Name of ProxyStore backend yo use for transferring large objects")
+    proxystore_threshold: Optional[int] = Field(None, description="Proxy all input/output objects larger than this threshold in bytes")
 
     def __init__(self, inputs: Tuple[Tuple[Any], Dict[str, Any]], **kwargs):
         """
@@ -138,6 +136,15 @@ class Result(BaseModel):
     @property
     def kwargs(self) -> Dict[str, Any]:
         return self.inputs[1]
+
+    def json(self, **kwargs: Dict[str, Any]) -> str:
+        """Override json encoder to use a custom encoder with proxy support"""
+        if 'encoder' not in kwargs:
+            # Only use the Colmena custom encoder if the user did not specify
+            # one. If the user specifies a custom encoder, we trust that they
+            # know what they are doing.
+            kwargs['encoder'] = proxy_json_encoder
+        return super().json(**kwargs)
 
     def mark_result_received(self):
         """Mark that a completed computation was received by a client"""
@@ -186,29 +193,27 @@ class Result(BaseModel):
         def _serialize_and_proxy(value, evict=False):
             """Helper function for serializing and proxying"""
             # Serialized object before proxying to compare size of serialized
-            # object to value server threshold
+            # object to value server threshold. Using sys.getsizeof would be
+            # faster but sys.getsizeof does not account for the memory
+            # consumption of objects that value refers to
             value_str = SerializationMethod.serialize(
                 self.serialization_method, value
             )
 
             if (
-                    self.value_server_threshold is not None and
-                    sys.getsizeof(value_str) >= self.value_server_threshold and
+                    self.proxystore_threshold is not None and
+                    sys.getsizeof(value_str) >= self.proxystore_threshold and
                     not isinstance(value, ps.proxy.Proxy)
             ):
-                # Proxy the value. Note: we use the id of the object as the key
-                # so calling proxy() on the same object multiple times
-                # does not create multiple copies in the value server.
-                value_proxy = colmena.proxy.proxy(
-                    value_str,
-                    key=str(id(value)),
-                    is_serialized=True,
-                    serialization_method=self.serialization_method,
-                    evict=evict
+                # Proxy the value. We use the id of the object as the key
+                # so multiple copies of the object are not added to ProxyStore,
+                # but the value in ProxyStore will still be updated.
+                value_proxy = ps.store.get_store(self.proxystore_name).proxy(
+                    value, key=str(id(value)), evict=evict,
                 )
                 logger.debug(f'Proxied object of type {type(value)} with id={id(value)}')
-                # Serialize the proxy. This is efficient since the proxy is
-                # just a reference + metadata about the value
+                # Serialize the proxy with Colmena's utilities. This is
+                # efficient since the proxy is just a reference and metadata
                 value_str = SerializationMethod.serialize(
                     self.serialization_method, value_proxy
                 )

--- a/colmena/models.py
+++ b/colmena/models.py
@@ -142,7 +142,7 @@ class Result(BaseModel):
         data = {
             'inputs': self.inputs,
             'value': self.value,
-            **super().dict(exclude={'inputs', 'value'}
+            **super().dict(exclude={'inputs', 'value'})
         }
         return json.dumps(data, default=proxy_json_encoder)
 

--- a/colmena/models.py
+++ b/colmena/models.py
@@ -201,9 +201,10 @@ class Result(BaseModel):
             )
 
             if (
+                    self.proxystore_name is not None and
                     self.proxystore_threshold is not None and
-                    sys.getsizeof(value_str) >= self.proxystore_threshold and
-                    not isinstance(value, ps.proxy.Proxy)
+                    not isinstance(value, ps.proxy.Proxy) and
+                    sys.getsizeof(value_str) >= self.proxystore_threshold
             ):
                 # Proxy the value. We use the id of the object as the key
                 # so multiple copies of the object are not added to ProxyStore,

--- a/colmena/models.py
+++ b/colmena/models.py
@@ -146,7 +146,7 @@ class Result(BaseModel):
     def kwargs(self) -> Dict[str, Any]:
         return self.inputs[1]
 
-    def json(self, *args, **kwargs: Dict[str, Any]) -> str:
+    def json(self, **kwargs: Dict[str, Any]) -> str:
         """Override json encoder to use a custom encoder with proxy support"""
         if 'exclude' in kwargs:
             # Make a shallow copy of the user passed excludes
@@ -178,10 +178,6 @@ class Result(BaseModel):
 
         # Jsonify with custom proxy encoder
         return json.dumps(data, default=proxy_json_encoder)
-        
-        #assert 'encoder' not in kwargs, "Colmena already sets a default encoder."
-        #kwargs['encoder'] = proxy_json_encoder
-        #return super(Result, self).json(*args, **kwargs)
 
     def mark_result_received(self):
         """Mark that a completed computation was received by a client"""

--- a/colmena/models.py
+++ b/colmena/models.py
@@ -139,12 +139,12 @@ class Result(BaseModel):
 
     def json(self, **kwargs: Dict[str, Any]) -> str:
         """Override json encoder to use a custom encoder with proxy support"""
-        if 'encoder' not in kwargs:
-            # Only use the Colmena custom encoder if the user did not specify
-            # one. If the user specifies a custom encoder, we trust that they
-            # know what they are doing.
-            kwargs['encoder'] = proxy_json_encoder
-        return super().json(**kwargs)
+        data = {
+            'inputs': self.inputs,
+            'value': self.value,
+            **super().dict(exclude={'inputs', 'value'}
+        }
+        return json.dumps(data, default=proxy_json_encoder)
 
     def mark_result_received(self):
         """Mark that a completed computation was received by a client"""

--- a/colmena/proxy.py
+++ b/colmena/proxy.py
@@ -5,6 +5,10 @@ import proxystore as ps
 from typing import Any, Union
 
 
+class ProxyJSONSerializationWarning(Warning):
+    pass
+
+
 def proxy_json_encoder(proxy: ps.proxy.Proxy) -> Any:
     """Custom encoder function for proxies
 
@@ -45,7 +49,8 @@ def proxy_json_encoder(proxy: ps.proxy.Proxy) -> Any:
     warnings.warn(
         "Attemping to JSON serialize an unresolved proxy. To prevent "
         "an unintended proxy resolve, the resulting JSON object will "
-        "have unresolved proxies replaced with a placeholder string."
+        "have unresolved proxies replaced with a placeholder string.",
+        category=ProxyJSONSerializationWarning
     )
     return f"<Unresolved Proxy at {hex(id(proxy))}>"
 

--- a/colmena/redis/queue.py
+++ b/colmena/redis/queue.py
@@ -253,11 +253,11 @@ class ClientQueues:
         if isinstance(proxystore_name, str):
             self.proxystore_name = defaultdict(lambda: proxystore_name)
         elif isinstance(proxystore_name, dict):
-            self.proxystore_name = defaultdict(None)
+            self.proxystore_name = defaultdict(lambda: None)
             for topic, name in proxystore_name:
                 self.proxystore_name[topic] = name
         elif proxystore_name is None:
-            self.proxystore_name = defaultdict(None)
+            self.proxystore_name = defaultdict(lambda: None)
         else:
             raise ValueError(f'Unexpected type {type(proxystore_name)} for proxystore_name')
 
@@ -265,11 +265,11 @@ class ClientQueues:
         if isinstance(proxystore_threshold, int):
             self.proxystore_threshold = defaultdict(lambda: proxystore_threshold)
         elif isinstance(proxystore_threshold, dict):
-            self.proxystore_threshold = defaultdict(None)
+            self.proxystore_threshold = defaultdict(lambda: None)
             for topic, name in proxystore_threshold:
                 self.proxystore_threshold[topic] = name
         elif proxystore_threshold is None:
-            self.proxystore_threshold = defaultdict(None)
+            self.proxystore_threshold = defaultdict(lambda: None)
         else:
             raise ValueError(f'Unexpected type {type(proxystore_threshold)} for proxystore_threshold')
 
@@ -294,7 +294,7 @@ class ClientQueues:
         # Log the ProxyStore configuration
         for topic in _topics:
             name = self.proxystore_name[topic]
-            threshold = self.proxystore_threshold[name]
+            threshold = self.proxystore_threshold[topic]
             if name is None or threshold is None:
                 logger.debug(f'Topic {topic} will not use ProxyStore')
             else:

--- a/colmena/redis/queue.py
+++ b/colmena/redis/queue.py
@@ -254,8 +254,7 @@ class ClientQueues:
             self.proxystore_name = defaultdict(lambda: proxystore_name)
         elif isinstance(proxystore_name, dict):
             self.proxystore_name = defaultdict(lambda: None)
-            for topic, ps_name in proxystore_name:
-                self.proxystore_name[topic] = ps_name
+            self.proxystore_name.update(proxystore_name)
         elif proxystore_name is None:
             self.proxystore_name = defaultdict(lambda: None)
         else:
@@ -266,8 +265,7 @@ class ClientQueues:
             self.proxystore_threshold = defaultdict(lambda: proxystore_threshold)
         elif isinstance(proxystore_threshold, dict):
             self.proxystore_threshold = defaultdict(lambda: None)
-            for topic, threshold in proxystore_threshold:
-                self.proxystore_threshold[topic] = threshold
+            self.proxystore_threshold.update(proxystore_threshold)
         elif proxystore_threshold is None:
             self.proxystore_threshold = defaultdict(lambda: None)
         else:
@@ -280,7 +278,7 @@ class ClientQueues:
             store = ps.store.get_store(ps_name)
             if store is None:
                 raise ValueError(
-                    f'ProxyStore backend with name {ps_name} was not '
+                    f'ProxyStore backend with name "{ps_name}" was not '
                     'found. This is likely because the store needs to be '
                     'initialized prior to initializing the Colmena queues.'
                 )
@@ -300,7 +298,7 @@ class ClientQueues:
                 logger.debug(f'Topic {topic} will not use ProxyStore')
             else:
                 logger.debug(
-                    f'Topic {topic} will use ProxyStore backend {ps_name} '
+                    f'Topic {topic} will use ProxyStore backend "{ps_name}" '
                     f'with a threshold of {ps_threshold} bytes'
                 )
 

--- a/colmena/redis/queue.py
+++ b/colmena/redis/queue.py
@@ -254,8 +254,8 @@ class ClientQueues:
             self.proxystore_name = defaultdict(lambda: proxystore_name)
         elif isinstance(proxystore_name, dict):
             self.proxystore_name = defaultdict(lambda: None)
-            for topic, name in proxystore_name:
-                self.proxystore_name[topic] = name
+            for topic, ps_name in proxystore_name:
+                self.proxystore_name[topic] = ps_name
         elif proxystore_name is None:
             self.proxystore_name = defaultdict(lambda: None)
         else:
@@ -266,21 +266,21 @@ class ClientQueues:
             self.proxystore_threshold = defaultdict(lambda: proxystore_threshold)
         elif isinstance(proxystore_threshold, dict):
             self.proxystore_threshold = defaultdict(lambda: None)
-            for topic, name in proxystore_threshold:
-                self.proxystore_threshold[topic] = name
+            for topic, threshold in proxystore_threshold:
+                self.proxystore_threshold[topic] = threshold
         elif proxystore_threshold is None:
             self.proxystore_threshold = defaultdict(lambda: None)
         else:
             raise ValueError(f'Unexpected type {type(proxystore_threshold)} for proxystore_threshold')
 
         # Verify that ProxyStore backends exist
-        for name in set(self.proxystore_name.values()):
-            if name is None:
+        for ps_name in set(self.proxystore_name.values()):
+            if ps_name is None:
                 continue
-            store = ps.store.get_store(name)
+            store = ps.store.get_store(ps_name)
             if store is None:
                 raise ValueError(
-                    f'ProxyStore backend with name {proxystore_name} was not '
+                    f'ProxyStore backend with name {ps_name} was not '
                     'found. This is likely because the store needs to be '
                     'initialized prior to initializing the Colmena queues.'
                 )
@@ -293,14 +293,15 @@ class ClientQueues:
 
         # Log the ProxyStore configuration
         for topic in _topics:
-            name = self.proxystore_name[topic]
-            threshold = self.proxystore_threshold[topic]
-            if name is None or threshold is None:
+            ps_name = self.proxystore_name[topic]
+            ps_threshold = self.proxystore_threshold[topic]
+
+            if ps_name is None or ps_threshold is None:
                 logger.debug(f'Topic {topic} will not use ProxyStore')
             else:
                 logger.debug(
-                    f'Topic {topic} will use ProxyStore backend {name} with a '
-                    f'threshold of {threshold} bytes'
+                    f'Topic {topic} will use ProxyStore backend {ps_name} '
+                    f'with a threshold of {ps_threshold} bytes'
                 )
 
         # Make the queues

--- a/colmena/task_server/parsl.py
+++ b/colmena/task_server/parsl.py
@@ -2,7 +2,7 @@
 import os
 import logging
 from concurrent.futures import Future
-from functools import partial
+from functools import partial, update_wrapper
 from typing import Optional, List, Callable, Tuple, Dict, Union
 
 import parsl
@@ -108,6 +108,7 @@ class ParslTaskServer(FutureBasedTaskServer):
 
             # Wrap the function in the timer class
             wrapped_function = partial(run_and_record_timing, function)
+            wrapped_function = update_wrapper(wrapped_function, function)
             app = PythonApp(wrapped_function, **options)
 
             # Store it

--- a/colmena/version.py
+++ b/colmena/version.py
@@ -3,4 +3,4 @@
 <Major>.<Minor>.<maintenance>[alpha/beta/..]
 Alphas will be numbered like this -> 0.4.0a0
 """
-VERSION = '0.1.3'
+VERSION = '0.2.0'

--- a/demo_apps/funcx/run.py
+++ b/demo_apps/funcx/run.py
@@ -136,7 +136,7 @@ if __name__ == '__main__':
     parser.add_argument('--opt-delay', help="Minimum runtime for the optimizer", type=float, default=0.0)
     parser.add_argument('--runtime', help="Natural logarithm of average runtime for the target function", type=float, default=2)
     parser.add_argument('--runtime-var', help="Natural logarithm of runtime variance for the target function", type=float, default=0.1)
-    parser.add_argument('--proxystore-threshold', help="Threshold (bytes) for using ProxyStore with a Redis backend for moving inputs/results", type=int, default=None)
+    parser.add_argument('--proxystore-threshold', help="Threshold (bytes) for using ProxyStore with a Redis backend for moving inputs/results. This requires the FuncX endpoint and driver being on the same system.", type=int, default=None)
     parser.add_argument('endpoint', help='FuncX endpoing on which to execute tasks', type=str)
     args = parser.parse_args()
 

--- a/demo_apps/funcx/run.py
+++ b/demo_apps/funcx/run.py
@@ -16,6 +16,7 @@ import logging
 import json
 import sys
 import os
+import proxystore as ps
 
 
 # Hard code the function to be optimized
@@ -135,14 +136,9 @@ if __name__ == '__main__':
     parser.add_argument('--opt-delay', help="Minimum runtime for the optimizer", type=float, default=0.0)
     parser.add_argument('--runtime', help="Natural logarithm of average runtime for the target function", type=float, default=2)
     parser.add_argument('--runtime-var', help="Natural logarithm of runtime variance for the target function", type=float, default=0.1)
+    parser.add_argument('--proxystore-threshold', help="Threshold (bytes) for using ProxyStore with a Redis backend for moving inputs/results", type=int, default=None)
     parser.add_argument('endpoint', help='FuncX endpoing on which to execute tasks', type=str)
     args = parser.parse_args()
-
-    # Connect to the redis server
-    client_queues, server_queues = make_queue_pairs(args.redishost, args.redisport, serialization_method='json')
-
-    # Log in to FuncX
-    fx_client = FuncXClient()
 
     # Make the output directory
     out_dir = os.path.join('runs',
@@ -159,6 +155,29 @@ if __name__ == '__main__':
                         level=logging.INFO,
                         handlers=[logging.FileHandler(os.path.join(out_dir, 'runtime.log')),
                                   logging.StreamHandler(sys.stdout)])
+
+    if args.proxystore_threshold is not None:
+        ps.store.init_store(
+            ps.store.STORES.REDIS,
+            name='default',
+            hostname=args.redishost,
+            port=args.redisport
+        )
+        serialization_method = 'pickle'
+    else:
+        serialization_method = 'json'
+
+    # Connect to the redis server
+    client_queues, server_queues = make_queue_pairs(
+        args.redishost,
+        args.redisport,
+        serialization_method=serialization_method,
+        proxystore_name='default',
+        proxystore_threshold=args.proxystore_threshold
+    )
+
+    # Log in to FuncX
+    fx_client = FuncXClient()
 
     # Create the task server and task generator
     my_ackley = partial(ackley, mean_rt=args.runtime, std_rt=args.runtime_var)

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -47,16 +47,31 @@ We setup the Redis queues in Python using Colmena's "queue building" function:
 This command connects to a server on localhost and creates separates queues for simulation and task
 generation results.
 
-Using the Value Server
-++++++++++++++++++++++
+Using ProxyStore
+++++++++++++++++
 
-Colmena uses `ProxyStore <https://github.com/gpauloski/ProxyStore>`_ to implement a Redis-based value server.
-The value server can be used to efficiently transfer large objects, typically on the order of 100KB or larger, between the thinker and workers directly.
-To enable the value server, a threshold value (bytes) can be passed via the parameter :code:`value_server_threshold` to :code:`make_queue_pairs`.
-Any input/output object of a target function larger than :code:`value_server_threshold` will be automatically passed via the value server.
+Colmena can use `ProxyStore <https://github.com/gpauloski/ProxyStore>`_ to efficiently transfer large objects, typically on the order of 100KB or larger, between the thinker and workers directly.
+To enable the use of ProxyStore, a ProxyStore backend must be initialized.
+The name of the ProxyStore backend and a threshold value (bytes) can be passed via the parameters :code:`proxystore_name` and :code:`proxystore_threshold` to :code:`make_queue_pairs`.
+Any input/output object of a target function larger than :code:`proxystore_threshold` will be automatically passed via ProxyStore.
 
-By default, the value server uses the Redis server passed to :code:`make_queue_pairs`.
-An alternative Redis server for the value server can be specified via the :code:`value_server_hostname` and :code:`value_server_port` parameters of :code:`make_queue_pairs`.
+For example, a common use case is to initialize ProxyStore to use the same Redis server that Colmena uses for the queues.
+
+.. code-block:: python
+
+    import proxystore as ps
+    from colmena.redis.queue import make_queue_pairs
+
+    ps.store.init_store(
+        'redis', name='default-store', hostname=REDISHOST, port=REDISPORT
+    )
+
+    client_queues, server_queues = make_queue_pairs(
+        REDISHOST, REDISPORT, serialization_method='pickle',
+        proxystore_name='default-store', proxystore_threshold=100000
+    )
+
+More details on initializing ProxyStore backends can be found in the `docs <https://proxystore.readthedocs.io/en/latest/source/proxystore.store.html>`_.
 
 2. Build a task server
 ----------------------

--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,4 @@ dependencies:
       - -e .
       - parsl>=1.*
       - pydantic
-      - proxystore==0.2.*
+      - proxystore==0.3.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 parsl>=1
 pydantic==1.*
 redis==3.4.*
-proxystore==0.2.*
+proxystore==0.3.*


### PR DESCRIPTION
**Note:** Opening this to discuss ideas so not ready to merge.

Changes:
- Updated to `ProxyStore>=0.3.*`
- Changed references to `value_server` to `proxystore` for clarity.
- Colmena no longer forces Redis backed for ProxyStore. Rather, we leave it up to the user to initialize the ProxyStore backend they want to use and then pass the name of the ProxyStore backend to `ClientQueues`.
- Fixed proxy not jsonable error when using `Result.json()`. To prevent accidentally resolving a proxy, the `Result.json()` method is modified to raise a warning if a user tries to jsonify a Result that contains an unresolved proxy.
- Update docs and funcx example.

Ideas:
- `ClientQueues` takes the name of the ProxyStore backend to use, but we could also allow it to take an iterable of ProxyStore backends to use with each topic. I.e., if you have two topics `['simulate', 'train']` and want to use a Redis ProxyStore backend for 'simulate' and Globus for 'train', you could pass `proxystore_name=['my-redis-backend', 'my-globus-backend']` (assuming you have initialized the backends already).