### PR TITLE
rename ptype/dfk cleanup/numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy
 parsl>=1
 pydantic==1.*
 redis==3.4.*


### PR DESCRIPTION
This PR provides:

1. Rename for `ptype` to `cpu_processes`
2. Ensure `dfk.cleanup()` on parsl level.
3. Add `numpy` as a requirement