### PR TITLE
Capture proxy statistics

### DIFF
--- a/colmena/models.py
+++ b/colmena/models.py
@@ -16,15 +16,11 @@ from typing import Any, Tuple, Dict, Optional, Union, List
 from uuid import uuid4
 
 from pydantic import BaseModel, Field, Extra
-from pydantic.dataclasses import dataclass as pyddataclass
 import proxystore as ps
 
 from colmena.proxy import proxy_json_encoder
 
 logger = logging.getLogger(__name__)
-
-
-ProxyTimeStats = pyddataclass(ps.store.base.TimeStats)
 
 
 # TODO (wardlt): Merge with FuncX's approach?
@@ -151,8 +147,8 @@ class Result(BaseModel):
 
     additional_timing: dict = Field(default_factory=dict,
                                     description="Timings recorded by a TaskServer that are not defined by above")
-    proxy_timing: Dict[str, Dict[str, ProxyTimeStats]] = Field(default_factory=dict,
-                                                               description='Timings related to resolving ProxyStore proxies on the compute worker')
+    proxy_timing: Dict[str, Dict[str, dict]] = Field(default_factory=dict,
+                                                     description='Timings related to resolving ProxyStore proxies on the compute worker')
 
     # Serialization options
     serialization_method: SerializationMethod = Field(SerializationMethod.JSON,

--- a/colmena/models.py
+++ b/colmena/models.py
@@ -16,12 +16,15 @@ from typing import Any, Tuple, Dict, Optional, Union, List
 from uuid import uuid4
 
 from pydantic import BaseModel, Field, Extra
-
+from pydantic.dataclasses import dataclass as pyddataclass
 import proxystore as ps
 
 from colmena.proxy import proxy_json_encoder
 
 logger = logging.getLogger(__name__)
+
+
+ProxyTimeStats = pyddataclass(ps.store.base.TimeStats)
 
 
 # TODO (wardlt): Merge with FuncX's approach?
@@ -148,14 +151,15 @@ class Result(BaseModel):
 
     additional_timing: dict = Field(default_factory=dict,
                                     description="Timings recorded by a TaskServer that are not defined by above")
+    proxy_timing: Dict[str, Dict[str, ProxyTimeStats]] = Field(default_factory=dict,
+                                                               description='Timings related to resolving ProxyStore proxies on the compute worker')
 
     # Serialization options
     serialization_method: SerializationMethod = Field(SerializationMethod.JSON,
                                                       description="Method used to serialize input data")
     keep_inputs: bool = Field(True, description="Whether to keep the inputs with the result object or delete "
                                                 "them after the method has completed")
-    proxystore_name: Optional[str] = Field(None,
-                                           description="Name of ProxyStore backend yo use for transferring large objects")
+    proxystore_name: Optional[str] = Field(None, description="Name of ProxyStore backend you use for transferring large objects")
     proxystore_type: Optional[str] = Field(None, description="Type of ProxyStore backend being used")
     proxystore_kwargs: Optional[Dict] = Field(None, description="Kwargs to reinitialize ProxyStore backend")
     proxystore_threshold: Optional[int] = Field(None,

--- a/colmena/proxy.py
+++ b/colmena/proxy.py
@@ -88,8 +88,8 @@ def resolve_proxies_async(args: Union[object, list, tuple, dict]) -> List[ps.pro
         resolve_async_if_proxy(args)
     elif isinstance(args, list) or isinstance(args, tuple):
         for x in args:
-            output.extend(resolve_proxies_async(x))
+            resolve_async_if_proxy(x)
     elif isinstance(args, dict):
         for x in args:
-            output.extend(resolve_proxies_async(args[x]))
+            resolve_async_if_proxy(args[x])
     return output

--- a/colmena/proxy.py
+++ b/colmena/proxy.py
@@ -3,7 +3,7 @@ import logging
 import warnings
 import proxystore as ps
 
-from typing import Any, Union, NoReturn, List
+from typing import Any, Union, List
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ def resolve_proxies_async(args: Union[object, list, tuple, dict]) -> List[ps.pro
     output = []
 
     # Make a function that will resolve proxies
-    def resolve_async_if_proxy(obj: Any) -> NoReturn:
+    def resolve_async_if_proxy(obj: Any) -> None:
         if isinstance(obj, ps.proxy.Proxy):
             output.append(obj)
             ps.proxy.resolve_async(obj)

--- a/colmena/proxy.py
+++ b/colmena/proxy.py
@@ -3,7 +3,7 @@ import logging
 import warnings
 import proxystore as ps
 
-from typing import Any, Union
+from typing import Any, Union, NoReturn, List
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ def proxy_json_encoder(proxy: ps.proxy.Proxy) -> Any:
     return f"<Unresolved Proxy at {hex(id(proxy))}>"
 
 
-def resolve_proxies_async(args: Union[object, list, tuple, dict]) -> None:
+def resolve_proxies_async(args: Union[object, list, tuple, dict]) -> List[ps.proxy.Proxy]:
     """Begin asynchronously resolving all proxies in input
 
     Scan inputs for instances of `Proxy` and begin asynchronously resolving.
@@ -70,9 +70,18 @@ def resolve_proxies_async(args: Union[object, list, tuple, dict]) -> None:
     Args:
         args (object, list, tuple, dict): possible object or
             iterable of objects that may be ObjectProxy instances
+
+    Returns:
+        List of the proxies that are being resolved
     """
-    def resolve_async_if_proxy(obj: Any) -> None:
+
+    # Create a list to store the keys
+    output = []
+
+    # Make a function that will resolve proxies
+    def resolve_async_if_proxy(obj: Any) -> NoReturn:
         if isinstance(obj, ps.proxy.Proxy):
+            output.append(obj)
             ps.proxy.resolve_async(obj)
 
     if isinstance(args, ps.proxy.Proxy):
@@ -83,3 +92,4 @@ def resolve_proxies_async(args: Union[object, list, tuple, dict]) -> None:
     elif isinstance(args, dict):
         for x in args:
             resolve_async_if_proxy(args[x])
+    return output

--- a/colmena/proxy.py
+++ b/colmena/proxy.py
@@ -88,8 +88,8 @@ def resolve_proxies_async(args: Union[object, list, tuple, dict]) -> List[ps.pro
         resolve_async_if_proxy(args)
     elif isinstance(args, list) or isinstance(args, tuple):
         for x in args:
-            resolve_async_if_proxy(x)
+            output.extend(resolve_proxies_async(x))
     elif isinstance(args, dict):
         for x in args:
-            resolve_async_if_proxy(args[x])
+            output.extend(resolve_proxies_async(args[x]))
     return output

--- a/colmena/task_server/base.py
+++ b/colmena/task_server/base.py
@@ -215,5 +215,7 @@ def run_and_record_timing(func: Callable, result: Result) -> Result:
 
             # Store the data along with the stats
             result.proxy_timing[key] = stats
+        else:
+            result.proxy_timing[key] = {}
 
     return result

--- a/colmena/task_server/base.py
+++ b/colmena/task_server/base.py
@@ -2,12 +2,15 @@
 import logging
 import os
 import platform
+from dataclasses import asdict
 from abc import ABCMeta, abstractmethod
 from concurrent.futures import Future
 from inspect import signature
 from multiprocessing import Process
 from time import perf_counter
 from typing import Optional, Callable
+
+import proxystore as ps
 
 from colmena.exceptions import KillSignalException, TimeoutException
 from colmena.models import Result, FailureInformation
@@ -161,8 +164,8 @@ def run_and_record_timing(func: Callable, result: Result) -> Result:
 
     # Start resolving any proxies in the input asynchronously
     start_time = perf_counter()
-    resolve_proxies_async(result.args)
-    resolve_proxies_async(result.kwargs)
+    proxies = resolve_proxies_async(result.args)
+    proxies.extend(resolve_proxies_async(result.kwargs))
     result.time_async_resolve_proxies = perf_counter() - start_time
 
     # Execute the function
@@ -198,5 +201,19 @@ def run_and_record_timing(func: Callable, result: Result) -> Result:
 
     # Re-pack the results
     result.time_serialize_results = result.serialize()
+
+    # Get the statistics for the proxy resolution
+    for proxy in proxies:
+        store = ps.store.get_store(proxy)
+        if store.has_stats:
+            # Get the stats and convert them to a JSON-serializable form
+            stats = store.stats(proxy)
+            stats = dict((k, asdict(v)) for k, v in stats.items())
+
+            # Get the key associated with this proxy
+            key = ps.proxy.get_key(proxy)
+
+            # Store the data along with the stats
+            result.proxy_timing[key] = stats
 
     return result

--- a/colmena/task_server/base.py
+++ b/colmena/task_server/base.py
@@ -164,8 +164,11 @@ def run_and_record_timing(func: Callable, result: Result) -> Result:
 
     # Start resolving any proxies in the input asynchronously
     start_time = perf_counter()
-    proxies = resolve_proxies_async(result.args)
-    proxies.extend(resolve_proxies_async(result.kwargs))
+    proxies = []
+    for arg in result.args:
+        proxies.extend(resolve_proxies_async(arg))
+    for value in result.kwargs.values():
+        proxies.extend(resolve_proxies_async(value))
     result.time_async_resolve_proxies = perf_counter() - start_time
 
     # Execute the function

--- a/colmena/task_server/tests/test_parsl.py
+++ b/colmena/task_server/tests/test_parsl.py
@@ -6,7 +6,6 @@ from parsl.config import Config
 from pytest import fixture, mark
 import proxystore as ps
 
-
 from colmena.models import ResourceRequirements
 from .test_base import EchoTask, FakeMPITask
 from colmena.redis.queue import ClientQueues, make_queue_pairs
@@ -192,3 +191,4 @@ def test_proxy(server_and_queue):
     result = queue.get_result()
     assert result.success, result.failure_info.exception
     assert len(result.proxy_timing) == 1  # There is one proxy to resolve
+    assert len(result.json()) > 0

--- a/colmena/task_server/tests/test_parsl.py
+++ b/colmena/task_server/tests/test_parsl.py
@@ -16,7 +16,7 @@ def f(x):
     return x + 1
 
 
-def capitalize(y: List[str], x: str):
+def capitalize(y: List[str], x: str, **kwargs):
     return x.upper(), [i.lower() for i in y]
 
 
@@ -202,5 +202,11 @@ def test_proxy(server_and_queue, store):
     queue.send_inputs([little_proxy], big_string, method='capitalize')
     result = queue.get_result()
     assert result.success, result.failure_info.exception
-    assert len(result.proxy_timing) == 2  # There is one proxy to resolve
-    assert len(result.json()) > 0
+    assert len(result.proxy_timing) == 2
+
+    # Try it with a kwarg
+    queue.send_inputs(['a'], big_string, input_kwargs={'little': little_proxy}, method='capitalize',
+                      keep_inputs=False)  # TODO (wardlt): test does not work with keep-inputs=True
+    result = queue.get_result()
+    assert result.success, result.failure_info.exception
+    assert len(result.proxy_timing) == 2

--- a/colmena/task_server/tests/test_parsl.py
+++ b/colmena/task_server/tests/test_parsl.py
@@ -38,10 +38,12 @@ def config():
         strategy=None,
     )
 
+
 # Make a proxy store for larger objects
 @fixture()
 def store():
     return ps.store.init_store(ps.store.STORES.REDIS, name='store', hostname='localhost', port=6379, stats=True)
+
 
 @fixture(autouse=True)
 def server_and_queue(config, store) -> Tuple[ParslTaskServer, ClientQueues]:
@@ -202,4 +204,3 @@ def test_proxy(server_and_queue, store):
     assert result.success, result.failure_info.exception
     assert len(result.proxy_timing) == 2  # There is one proxy to resolve
     assert len(result.json()) > 0
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy
 parsl>=1
 pydantic==1.*
 redis==3.4.*
-proxystore>=0.3.1
+proxystore>=0.3.3


### PR DESCRIPTION
Adds support for measuring the timing associated with reading a proxy on the remote system

1. Provide a place for storing it in the data model
2. Capture the list of proxies when resolving them during execution
3. Recover the statistics after the function completes

Requires an update to ProxyStore: https://github.com/gpauloski/proxystore/pull/43