### PR TITLE
Assess code coverage for multiprocessing workers

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
 omit = */tests/*
+concurrency = thread,multiprocessing

--- a/colmena/task_server/tests/test_parsl.py
+++ b/colmena/task_server/tests/test_parsl.py
@@ -35,7 +35,7 @@ def count_nodes(x, _resources: ResourceRequirements):
 def config(tmpdir):
     return Config(
         executors=[
-            HighThroughputExecutor()
+            HighThroughputExecutor(max_workers=1, address='localhost')
         ],
         strategy=None,
         run_dir=str(tmpdir),


### PR DESCRIPTION
Turns out, there is just a single line in a configuration file you need. Thanks, @gpauloski, for pointing that out!