### PR TITLE
Upgrade to Proxystore v0.4.0

### DIFF
--- a/colmena/proxy.py
+++ b/colmena/proxy.py
@@ -1,18 +1,65 @@
 """Utilities for interacting with ProxyStore"""
 import logging
 import warnings
-import proxystore as ps
 
-from typing import Any, Union, List
+import proxystore
+from proxystore.store.endpoint import EndpointStore
+from proxystore.store.file import FileStore
+from proxystore.store.globus import GlobusStore
+from proxystore.store.local import LocalStore
+from proxystore.store.redis import RedisStore
+from proxystore.proxy import extract
+from proxystore.proxy import is_resolved
+from proxystore.proxy import Proxy
+from proxystore.store.base import Store
+from proxystore.store.utils import resolve_async
+
+from typing import Any, Union, List, Optional, Type
 
 logger = logging.getLogger(__name__)
+
+STORES = {
+    'EndpointStore': EndpointStore,
+    'FileStore': FileStore,
+    'GlobusStore': GlobusStore,
+    'LocalStore': LocalStore,
+    'RedisStore': RedisStore,
+}
 
 
 class ProxyJSONSerializationWarning(Warning):
     pass
 
 
-def proxy_json_encoder(proxy: ps.proxy.Proxy) -> Any:
+def get_store(
+    name: str,
+    kind: Optional[Union[Type[Store], str]] = None,
+    **kwargs: Any,
+) -> Optional[Store]:
+    """Get a Store by name or create one if none exists.
+
+    Args:
+        name (str): name of the store.
+        kind (type[Store], str): type of store to initialize if one with the
+            same `name` is not found. If a string, the correct type will be
+            resolved using the ``STORES`` mapping. If ``None`` (the default),
+            no store will be initialized.
+        kwargs: keyword arguments to initialize the store with.
+
+    Returns:
+        The store registered as `name` or a newly intialized and registered
+        store if `kind` is not ``None``.
+    """
+    store = proxystore.store.get_store(name)
+    if store is None and kind is not None:
+        if isinstance(kind, str):
+            kind = STORES[kind]
+        store = kind(name=name, **kwargs)
+        proxystore.store.register_store(store)
+    return store
+
+
+def proxy_json_encoder(proxy: Proxy) -> Any:
     """Custom encoder function for proxies
 
     Proxy objects are not JSON serializable so this function, when passed to
@@ -40,15 +87,15 @@ def proxy_json_encoder(proxy: ps.proxy.Proxy) -> Any:
         TypeError:
             if `proxy` is not an instance of a Proxy.
     """
-    if not isinstance(proxy, ps.proxy.Proxy):
+    if not isinstance(proxy, Proxy):
         # The JSON encoder will catch this TypeError and handle appropriately
         logger.error(f'Passed a series of objects that are not serializable: {type(proxy)}. {proxy}')
         raise TypeError(f'Unserializable type: {type(proxy)}')
 
-    if ps.proxy.is_resolved(proxy):
+    if is_resolved(proxy):
         # Proxy is already resolved so encode the underlying object
         # rather than the proxy
-        return ps.proxy.extract(proxy)
+        return extract(proxy)
 
     warnings.warn(
         "Attemping to JSON serialize an unresolved proxy. To prevent "
@@ -59,7 +106,7 @@ def proxy_json_encoder(proxy: ps.proxy.Proxy) -> Any:
     return f"<Unresolved Proxy at {hex(id(proxy))}>"
 
 
-def resolve_proxies_async(args: Union[object, list, tuple, dict]) -> List[ps.proxy.Proxy]:
+def resolve_proxies_async(args: Union[object, list, tuple, dict]) -> List[Proxy]:
     """Begin asynchronously resolving all proxies in input
 
     Scan inputs for instances of `Proxy` and begin asynchronously resolving.
@@ -80,11 +127,11 @@ def resolve_proxies_async(args: Union[object, list, tuple, dict]) -> List[ps.pro
 
     # Make a function that will resolve proxies
     def resolve_async_if_proxy(obj: Any) -> None:
-        if isinstance(obj, ps.proxy.Proxy):
+        if isinstance(obj, Proxy):
             output.append(obj)
-            ps.proxy.resolve_async(obj)
+            resolve_async(obj)
 
-    if isinstance(args, ps.proxy.Proxy):
+    if isinstance(args, Proxy):
         resolve_async_if_proxy(args)
     elif isinstance(args, list) or isinstance(args, tuple):
         for x in args:

--- a/colmena/queue/base.py
+++ b/colmena/queue/base.py
@@ -9,6 +9,7 @@ import logging
 import proxystore as ps
 
 from colmena.models import Result, SerializationMethod, ResourceRequirements
+from colmena.proxy import get_class_path
 
 logger = logging.getLogger(__name__)
 
@@ -222,7 +223,7 @@ class ColmenaQueues:
                 'proxystore_threshold': self.proxystore_threshold[topic],
                 # Pydantic prefers to not have types as attributes so we
                 # get the string corresponding to the type of the store we use
-                'proxystore_type': store.__class__.__name__,
+                'proxystore_type': get_class_path(type(store)),
                 'proxystore_kwargs': store.kwargs
             })
 

--- a/colmena/queue/base.py
+++ b/colmena/queue/base.py
@@ -222,7 +222,7 @@ class ColmenaQueues:
                 'proxystore_threshold': self.proxystore_threshold[topic],
                 # Pydantic prefers to not have types as attributes so we
                 # get the string corresponding to the type of the store we use
-                'proxystore_type': ps.store.STORES.get_str_by_type(type(store)),
+                'proxystore_type': store.__class__.__name__,
                 'proxystore_kwargs': store.kwargs
             })
 

--- a/colmena/task_server/base.py
+++ b/colmena/task_server/base.py
@@ -10,7 +10,7 @@ from multiprocessing import Process
 from time import perf_counter
 from typing import Optional, Callable
 
-import proxystore as ps
+import proxystore
 
 from colmena.exceptions import KillSignalException, TimeoutException
 from colmena.models import Result, FailureInformation
@@ -220,10 +220,14 @@ def run_and_record_timing(func: Callable, result: Result) -> Result:
     # Get the statistics for the proxy resolution
     for proxy in proxies:
         # Get the key associated with this proxy
-        key = ps.proxy.get_key(proxy)
+        key = proxystore.store.utils.get_key(proxy)
+
+        # ProxyStore keys are NamedTuples so we cast to a string
+        # so we can use the key as a JSON key.
+        key = str(key)
 
         # Get the store associated with this proxy
-        store = ps.store.get_store(proxy)
+        store = proxystore.store.get_store(proxy)
         if store.has_stats:
             # Get the stats and convert them to a JSON-serializable form
             stats = store.stats(proxy)

--- a/colmena/task_server/tests/test_parsl.py
+++ b/colmena/task_server/tests/test_parsl.py
@@ -4,7 +4,8 @@ from typing import Tuple, List
 from parsl import HighThroughputExecutor
 from parsl.config import Config
 from pytest import fixture, mark
-import proxystore as ps
+import proxystore
+from proxystore.store.redis import RedisStore
 
 from colmena.queue.base import ColmenaQueues
 
@@ -43,9 +44,13 @@ def config(tmpdir):
 
 
 # Make a proxy store for larger objects
-@fixture()
+@fixture(scope='module')
 def store():
-    return ps.store.init_store(ps.store.STORES.REDIS, name='store', hostname='localhost', port=6379, stats=True)
+    store = RedisStore('store', hostname='localhost', port=6379, stats=True)
+    proxystore.store.register_store(store)
+    yield store
+    proxystore.store.unregister_store(store)
+    store.close()
 
 
 @fixture(autouse=True)

--- a/colmena/tests/test_proxy.py
+++ b/colmena/tests/test_proxy.py
@@ -1,0 +1,81 @@
+"""Test for ProxyStore utilities."""
+import json
+
+import pytest
+
+from proxystore.proxy import Proxy
+from proxystore.store import register_store
+from proxystore.store import unregister_store
+from proxystore.store.local import LocalStore
+
+from colmena.proxy import get_store
+from colmena.proxy import proxy_json_encoder
+from colmena.proxy import resolve_proxies_async
+
+
+@pytest.fixture
+def proxy() -> Proxy:
+    with LocalStore('proxy-fixture-store') as store:
+        yield store.proxy('test-value')
+
+
+def test_get_store_already_registered() -> None:
+    store = LocalStore('test-store')
+    register_store(store)
+    assert get_store('test-store') is store
+    unregister_store(store.name)
+
+
+def test_get_store_missing() -> None:
+    assert get_store('test-store') is None
+
+
+def test_get_store_initialize_by_type() -> None:
+    store = get_store('test-store', LocalStore, cache_size=0)
+    # Verify get_store registered the store globally by getting it again
+    assert get_store('test-store') is store
+    unregister_store(store.name)
+
+
+def test_get_store_initialize_by_str() -> None:
+    store = get_store('test-store', 'LocalStore', cache_size=0)
+    # Verify get_store registered the store globally by getting it again
+    assert get_store('test-store') is store
+    unregister_store(store.name)
+
+
+def test_proxy_json_encoder() -> None:
+    p = Proxy(lambda: 'test-value')
+    result = json.dumps({'proxy': p}, default=proxy_json_encoder)
+    reconstructed_data = json.loads(result)
+    assert 'proxy' in reconstructed_data
+
+
+def test_proxy_json_encoder_no_proxies() -> None:
+    # proxy_json_encoder should raise TypeError on non-Proxy types which
+    # were unable to be serialized by the default serializer
+    with pytest.raises(TypeError):
+        json.dumps({'a': lambda: 1}, default=proxy_json_encoder)
+
+
+def test_proxy_json_encoder_resolved_proxy(proxy) -> None:
+    # force the proxy to resolve
+    assert isinstance(proxy, str)
+    result = json.dumps({'proxy': proxy}, default=proxy_json_encoder)
+    assert result == '{"proxy": "test-value"}'
+
+
+def test_resolve_proxy_async_object_arg(proxy) -> None:
+    assert resolve_proxies_async(proxy) == [proxy]
+    assert resolve_proxies_async('not a proxy') == []
+
+
+def test_resolve_proxy_async_sequence_arg(proxy) -> None:
+    assert resolve_proxies_async([proxy, 'not a proxy']) == [proxy]
+    assert resolve_proxies_async((proxy, 'not a proxy')) == [proxy]
+
+
+def test_resolve_proxy_async_dict_arg(proxy) -> None:
+    assert resolve_proxies_async(
+        {'proxy': proxy, 'other': 'not a proxy'},
+    ) == [proxy]

--- a/colmena/tests/test_proxy.py
+++ b/colmena/tests/test_proxy.py
@@ -1,22 +1,64 @@
 """Test for ProxyStore utilities."""
 import json
+from typing import Any
+from typing import Type
 
 import pytest
 
 from proxystore.proxy import Proxy
 from proxystore.store import register_store
 from proxystore.store import unregister_store
+from proxystore.store.base import Store
+from proxystore.store.file import FileStore
 from proxystore.store.local import LocalStore
 
+from colmena.proxy import get_class_path
+from colmena.proxy import import_class
 from colmena.proxy import get_store
 from colmena.proxy import proxy_json_encoder
 from colmena.proxy import resolve_proxies_async
+
+
+class ExampleStore(Store):
+    pass
 
 
 @pytest.fixture
 def proxy() -> Proxy:
     with LocalStore('proxy-fixture-store') as store:
         yield store.proxy('test-value')
+
+
+@pytest.mark.parametrize(
+    'cls,expected',
+    (
+        (FileStore, 'proxystore.store.file.FileStore'),
+        (LocalStore, 'proxystore.store.local.LocalStore'),
+        # This directory has no __init__.py so the module is test_proxy
+        # rather than colmena.tests.test_proxy.
+        (ExampleStore, 'test_proxy.ExampleStore'),
+    ),
+)
+def test_get_class_path(cls: Type[Any], expected: str) -> None:
+    assert get_class_path(cls) == expected
+
+
+@pytest.mark.parametrize(
+    'path,expected',
+    (
+        ('proxystore.store.file.FileStore', FileStore),
+        ('proxystore.store.local.LocalStore', LocalStore),
+        ('test_proxy.ExampleStore', ExampleStore),
+        ('typing.Any', Any),
+    ),
+)
+def test_import_class(path: str, expected: Type[Any]) -> None:
+    assert import_class(path) == expected
+
+
+def test_import_class_missing_path() -> None:
+    with pytest.raises(ImportError):
+        import_class('FileStore')
 
 
 def test_get_store_already_registered() -> None:
@@ -38,7 +80,11 @@ def test_get_store_initialize_by_type() -> None:
 
 
 def test_get_store_initialize_by_str() -> None:
-    store = get_store('test-store', 'LocalStore', cache_size=0)
+    store = get_store(
+        'test-store',
+        'proxystore.store.local.LocalStore',
+        cache_size=0,
+    )
     # Verify get_store registered the store globally by getting it again
     assert get_store('test-store') is store
     unregister_store(store.name)

--- a/environment.yml
+++ b/environment.yml
@@ -19,5 +19,5 @@ dependencies:
       - -e .
       - git+https://github.com/parsl/parsl.git  # TODO (wardlt) 23Apr22: Remove when Parsl is pushed to PyPi next
       - pydantic
-      - proxystore>=0.3.1
+      - proxystore==0.4.*
       - funcx>=1.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy
 parsl>=1
 pydantic==1.*
 redis==3.4.*
-proxystore>=0.3.3
+proxystore==0.4.*


### PR DESCRIPTION
ProxyStore v0.4.0 was release 16 Jan. and has some breaking changes for Colmena (see [Changelog](https://proxystore.readthedocs.io/en/latest/changelog.html#version-0-4-0)).

I should have had Colmena pinned to v0.3 before, but unfortunately, I did not think that far ahead so any new install of Colmena will break because it will pull `proxystore==0.4.0` as a dependency. If pushing a new Colmena version to PyPI is easy, that would avoid some headaches.

Moving forward I've pinned Colmena to use `proxystore==0.4.*` because patch releases of ProxyStore will not contain breaking changes.

**Changes:**
- Lots of update module paths and imports.
- Replaced uses of `init_store` with initialize `Store` + `register_store`.
- Moved some code out of `Result` to `get_store` for readability and unit-testing.
  - Since the `STORES` enum was removed from ProxyStore, ProxyStore no longer has a mapping of `str: type[Store]` so I added one in `colmena.proxy.STORES`. This was necessary because the `proxystore_type` needs to be a string to be JSONable.
- ProxyStore keys are now `NamedTuples` so cast the key to a string when building the JSON object that stores proxy stats in the `Result`.
- The `colmena.proxy` now has 100% test coverage.