### PR TITLE
Improve the utility of the log

### DIFF
--- a/colmena/thinker/__init__.py
+++ b/colmena/thinker/__init__.py
@@ -49,7 +49,11 @@ def _result_event_agent(thinker: 'BaseThinker', process_func: Callable, topic: O
             result = thinker.queues.get_result(timeout=_DONE_REACTION_TIME, topic=topic)
         except TimeoutException:
             continue
+
+        thinker.logger.info(f'Started to process result for topic={topic}')
+        start_time = perf_counter()
         process_func(thinker, result)
+        thinker.logger.info(f'Finished processing result for topic={topic}. Runtime: {perf_counter() - start_time:.4f}s')
 
 
 def result_processor(func: Optional[Callable] = None, topic: str = 'default'):

--- a/colmena/thinker/__init__.py
+++ b/colmena/thinker/__init__.py
@@ -53,7 +53,7 @@ def _result_event_agent(thinker: 'BaseThinker', process_func: Callable, topic: O
         thinker.logger.info(f'Started to process result for topic={topic}')
         start_time = perf_counter()
         process_func(thinker, result)
-        thinker.logger.info(f'Finished processing result for topic={topic}. Runtime: {perf_counter() - start_time:.4f}s')
+        thinker.logger.info(f'Finished processing result for topic={topic}. Runtime: {perf_counter() - start_time:.4e}s')
 
 
 def result_processor(func: Optional[Callable] = None, topic: str = 'default'):
@@ -87,7 +87,10 @@ def _task_submitter_agent(thinker: 'BaseThinker', process_func: Callable, task_t
         # Wait until resources are free or thinker.done is set
         acq_success = thinker.rec.acquire(task_type, n_slots, cancel_if=thinker.done)
         if acq_success:
+            thinker.logger.info(f'Acquired {n_slots} execution slots of type {task_type}')
+            start_time = perf_counter()
             process_func(thinker)
+            thinker.logger.info(f'Finished submitting new work. Runtime: {perf_counter() - start_time:.4e}s')
 
 
 def task_submitter(func: Optional[Callable] = None, task_type: str = None, n_slots: Union[int, str] = 1):

--- a/colmena/thinker/tests/test_thinker.py
+++ b/colmena/thinker/tests/test_thinker.py
@@ -82,6 +82,21 @@ def test_detection():
     assert 'function' in [a.__name__ for a in ExampleThinker.list_agents()]
 
 
+def test_logger_name(queues):
+    """Test the name of loggers"""
+
+    class SimpleThinker(BaseThinker):
+        pass
+
+    # See if the default name holds
+    thinker = SimpleThinker(queues)
+    assert 'SimpleThinker' in thinker.logger.name
+
+    # See if we can provide it its own name
+    thinker = SimpleThinker(queues, logger_name='my_logger')
+    assert thinker.logger.name == 'my_logger'
+
+
 @mark.timeout(5)
 def test_run(queues):
     """Test the behavior of all agents"""


### PR DESCRIPTION
Let you directly assign the name of the thinker logs and add timings for the different response agents.

Fixes #93 