### PR TITLE
Update to Proxystore v0.5.0

### DIFF
--- a/colmena/models.py
+++ b/colmena/models.py
@@ -161,8 +161,7 @@ class Result(BaseModel):
     keep_inputs: bool = Field(True, description="Whether to keep the inputs with the result object or delete "
                                                 "them after the method has completed")
     proxystore_name: Optional[str] = Field(None, description="Name of ProxyStore backend you use for transferring large objects")
-    proxystore_type: Optional[str] = Field(None, description="Type of ProxyStore backend being used")
-    proxystore_kwargs: Optional[Dict] = Field(None, description="Kwargs to reinitialize ProxyStore backend")
+    proxystore_config: Optional[Dict] = Field(None, description="ProxyStore backend configuration")
     proxystore_threshold: Optional[int] = Field(None,
                                                 description="Proxy all input/output objects larger than this threshold in bytes")
 
@@ -307,8 +306,7 @@ class Result(BaseModel):
                 # but the value in ProxyStore will still be updated.
                 store = get_store(
                     name=self.proxystore_name,
-                    kind=self.proxystore_type,
-                    **self.proxystore_kwargs,
+                    config=self.proxystore_config,
                 )
                 value_proxy = store.proxy(value, evict=evict)
                 logger.debug(f'Proxied object of type {type(value)} with id={id(value)}')

--- a/colmena/tests/test_proxy.py
+++ b/colmena/tests/test_proxy.py
@@ -1,7 +1,5 @@
 """Test for ProxyStore utilities."""
 import json
-from typing import Any
-from typing import Type
 
 import pytest
 
@@ -9,11 +7,8 @@ from proxystore.proxy import Proxy
 from proxystore.store import register_store
 from proxystore.store import unregister_store
 from proxystore.store.base import Store
-from proxystore.store.file import FileStore
-from proxystore.store.local import LocalStore
+from proxystore.connectors.local import LocalConnector
 
-from colmena.proxy import get_class_path
-from colmena.proxy import import_class
 from colmena.proxy import get_store
 from colmena.proxy import proxy_json_encoder
 from colmena.proxy import resolve_proxies_async
@@ -25,69 +20,28 @@ class ExampleStore(Store):
 
 @pytest.fixture
 def proxy() -> Proxy:
-    with LocalStore('proxy-fixture-store') as store:
+    with Store('proxy-fixture-store', LocalConnector()) as store:
         yield store.proxy('test-value')
 
 
-@pytest.mark.parametrize(
-    'cls,expected',
-    (
-        (FileStore, 'proxystore.store.file.FileStore'),
-        (LocalStore, 'proxystore.store.local.LocalStore'),
-        # This directory has no __init__.py so the module is test_proxy
-        # rather than colmena.tests.test_proxy.
-        (ExampleStore, 'test_proxy.ExampleStore'),
-    ),
-)
-def test_get_class_path(cls: Type[Any], expected: str) -> None:
-    assert get_class_path(cls) == expected
-
-
-@pytest.mark.parametrize(
-    'path,expected',
-    (
-        ('proxystore.store.file.FileStore', FileStore),
-        ('proxystore.store.local.LocalStore', LocalStore),
-        ('test_proxy.ExampleStore', ExampleStore),
-        ('typing.Any', Any),
-    ),
-)
-def test_import_class(path: str, expected: Type[Any]) -> None:
-    assert import_class(path) == expected
-
-
-def test_import_class_missing_path() -> None:
-    with pytest.raises(ImportError):
-        import_class('FileStore')
-
-
 def test_get_store_already_registered() -> None:
-    store = LocalStore('test-store')
+    store = Store('test-store', LocalConnector())
     register_store(store)
     assert get_store('test-store') is store
-    unregister_store(store.name)
+    unregister_store(store)
 
 
 def test_get_store_missing() -> None:
     assert get_store('test-store') is None
 
 
-def test_get_store_initialize_by_type() -> None:
-    store = get_store('test-store', LocalStore, cache_size=0)
+def test_get_store_initialize_from_config() -> None:
+    # Create a temp store just to get the config
+    config = Store('test-store', LocalConnector()).config()
+    store = get_store('test-store', config)
     # Verify get_store registered the store globally by getting it again
     assert get_store('test-store') is store
-    unregister_store(store.name)
-
-
-def test_get_store_initialize_by_str() -> None:
-    store = get_store(
-        'test-store',
-        'proxystore.store.local.LocalStore',
-        cache_size=0,
-    )
-    # Verify get_store registered the store globally by getting it again
-    assert get_store('test-store') is store
-    unregister_store(store.name)
+    unregister_store(store)
 
 
 def test_proxy_json_encoder() -> None:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -47,29 +47,29 @@ Using ProxyStore
 ++++++++++++++++
 
 Colmena can use `ProxyStore <https://github.com/gpauloski/ProxyStore>`_ to efficiently transfer large objects, typically on the order of 100KB or larger, between the thinker and workers directly.
-To enable the use of ProxyStore, a ProxyStore backend must be initialized.
-The name of the ProxyStore backend and a threshold value (bytes) can be passed via the parameters :code:`proxystore_name` and :code:`proxystore_threshold` to :code:`make_queue_pairs`.
+Enable ProxyStore by initializing a `Store <https://docs.proxystore.dev/main/api/store/base/#proxystore.store.base.Store>`_ then passing the name (:code:`proxystore_name`) and threshold size (:code:`proxystore_threshold`) for the store to :code:`make_queue_pairs`.
 Any input/output object of a target function larger than :code:`proxystore_threshold` will be automatically passed via ProxyStore.
 
 For example, a common use case is to initialize ProxyStore to use a Redis server to communicate data directly to workers
 
 .. code-block:: python
 
-    import proxystore as ps
+    from proxystore.connectors.redis import RedisConnector
+    from proxystore.store import Store
+    from proxystore.store import register_store
     from colmena.queue import PipeQueues
 
-    ps.store.init_store(
-        'redis', name='default-store'
-    )
+    store = Store('redis', RedisConnector('localhost', 6379))
+    register_store(store)
 
     queue = PipeQueues(
-        proxystore_name='default-store',
+        proxystore_name='redis',
         proxystore_threshold=100000
     )
 
- Any object larger than 100kB will get sent via Redis, reducing the communication costs of your application.
+Any object larger than 100kB will get sent via Redis, reducing the communication costs of your application.
 
-More details on initializing ProxyStore backends can be found in the `docs <https://proxystore.readthedocs.io/en/latest/source/proxystore.store.html>`_.
+Learn more about ProxyStore and find the "Getting Started" guides at `docs.proxystore.dev <https://docs.proxystore.dev/>`_.
 
 2. Build a task server
 ----------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "parsl>=2022",
     "pydantic==1.*",
     "redis>=4.3",
-    "proxystore==0.4.*"
+    "proxystore==0.5.*"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This PR updates Colmena to use ProxyStore v0.5.0. The synthetic-data demo app is also updated.

Here's the changes to `colmena/` (i.e., ignoring the demo app and doc changes):

1. The `Store` now has [`.config()`](https://docs.proxystore.dev/main/api/store/base/#proxystore.store.base.Store.config) and [`.from_config()`](https://docs.proxystore.dev/main/api/store/base/#proxystore.store.base.Store.from_config) methods. This greatly simplifies the storing the ProxyStore configuration within each `Result` object and recreating the `Store` if necessary when serializing the `Result`.
2. The tests which use ProxyStore needed to be updated to use the new `Connector` model (a straightforward change).
3. The format of data returned by `store_proxy_stats` (which is stored in `Result`) has changed. While the data is more informative/human-readable, **this is a breaking change** for any code that parses `Result.proxy_timing`. An example can be found [here](https://docs.proxystore.dev/main/guides/performance/#a-simple-example), and a sample entry in `Result.proxy_timing` is provided below.

```python
>>> result.proxy_timing
{
    "FileKey(filename='7f4e12ba-622f-4946-ac01-9e3e5fee879d')": {
        "attributes": {"store.get.object_size": 1000165},
        "counters": {"store.get.cache_misses": 1},
        "times": {
            "store.get.connector": {
                "count": 1,
                "avg_time_ms": 189.037,
                "min_time_ms": 189.037,
                "max_time_ms": 189.037,
                "last_time_ms": 189.037,
                "last_timestamp": 1683940464.067098,
            },
            "store.get.deserialize": {
                "count": 1,
                "avg_time_ms": 427.167,
                "min_time_ms": 427.167,
                "max_time_ms": 427.167,
                "last_time_ms": 427.167,
                "last_timestamp": 1683940464.0675457,
            },
            "store.get": {
                "count": 1,
                "avg_time_ms": 689.462,
                "min_time_ms": 689.462,
                "max_time_ms": 689.462,
                "last_time_ms": 689.462,
                "last_timestamp": 1683940464.0675554,
            },
            "factory.resolve": {
                "count": 1,
                "avg_time_ms": 708.168,
                "min_time_ms": 708.168,
                "max_time_ms": 708.168,
                "last_time_ms": 708.168,
                "last_timestamp": 1683940464.0675676,
            },
            "factory.call": {
                "count": 1,
                "avg_time_ms": 768.181,
                "min_time_ms": 768.181,
                "max_time_ms": 768.181,
                "last_time_ms": 768.181,
                "last_timestamp": 1683940464.067604,
            },
        },
    },
}
```