### PR TITLE
Use a newer version of redis-py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "parsl>=2022",
     "pydantic==1.*",
-    "redis==3.4.*",
+    "redis>=4.3",
     "proxystore==0.4.*"
 ]
 


### PR DESCRIPTION
There are some vunerabilities, and I don't think we need to pin to this early version. 