### PR TITLE
Fix race condition for nonblocking resource reallocation

### DIFF
--- a/colmena/thinker/resources.py
+++ b/colmena/thinker/resources.py
@@ -213,7 +213,6 @@ class ResourceCounter:
 
             thr = Thread(target=_function, daemon=True)
             thr.start()
-            assert thr.is_alive(), thr.join()
             return True
 
         # Pull nodes from the remaining


### PR DESCRIPTION
Do not check if the thread is still running, as it might have already finished.