### PR TITLE
Improve serialization efficiency when objects are proxied

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "parsl>=2022",
     "pydantic==1.*",
     "redis>=4.3",
-    "proxystore==0.5.*"
+    "proxystore>=0.5.0,<0.7.0"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
To avoid double serialization of objects that end up being proxied, this PR passes a shim serializer and a deserializer wrapper to `store.proxy()` to take advantage of the fact we already have a serialized string when proxying an object.

Let me know what you think about this solution. I think it's the simplest in terms of implementation, but as I note in the commit message and code comment, there's still this conversion from `bytes -> str -> bytes` when using pickle as the Colmena serialization method.

Also increases the max supported version of ProxyStore to allow v0.6.

Fixes #117 
