### PR TITLE
Fix proxy deserialization bug from #120

### DIFF
--- a/colmena/models.py
+++ b/colmena/models.py
@@ -123,7 +123,7 @@ def _serialized_bytes_to_obj_wrapper(
     else:
         raise NotImplementedError(f'Method {method} not yet implemented')
 
-    return SerializationMethod.serialize(method, s)
+    return SerializationMethod.deserialize(method, s)
 
 
 class FailureInformation(BaseModel):


### PR DESCRIPTION
PR #120 introduced some shims for converting between Colmena's serialization utilities and ProxyStore's expected serialized type of bytes. One of these shims had a typo of "serialize" instead of "deserialize".

I think this did not get caught by CI because there's no test for queues with ProxyStore enabled, there's just tests for manually passing proxies as function inputs.

Fortunately, #120 hasn't made it into a release yet.


The failed Ci test (`test_reallocator_deadlock`) seems like it might be flakey. Everything passes fine locally.