### PR TITLE
Mark Colmena as having inline type hints

### DIFF
--- a/colmena/py.typed
+++ b/colmena/py.typed
@@ -1,0 +1,1 @@
+# PEP 561 marker file so mypy can use inline types.


### PR DESCRIPTION
The `py.typed` file distributed with the Colmena package marks Colmena as having inline type hints to third-party type checkers such as mypy.

Otherwise, mypy will warn you that it must skip checking import Colmena code.
```
error: Skipping analyzing "colmena.models": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

I've confirmed the build process includes the `py.typed` file correctly.
```bash
$ python3.11 -m venv venv
$ . venv/bin/activate
(venv) $ pip install build
(venv) $ python -m build --sdist --wheel --outdir dist/
(venv) $ unzip -l dist/colmena-0.5.2-py3-none-any.whl
Archive:  dist/colmena-0.5.2-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  03-04-2024 22:22   colmena/__init__.py
      233  03-04-2024 22:22   colmena/exceptions.py
    26564  03-04-2024 22:22   colmena/models.py
     5117  03-04-2024 22:22   colmena/proxy.py
       52  03-04-2024 22:23   colmena/py.typed
      274  03-04-2024 22:22   colmena/version.py
...
```