### PR TITLE
Bug fix: convert functions correctly

### DIFF
--- a/colmena/task_server/parsl.py
+++ b/colmena/task_server/parsl.py
@@ -353,7 +353,7 @@ class ParslTaskServer(FutureBasedTaskServer):
                 logger.info(f'Using default executors for {function.__name__}: {default_executors}')
 
             # Convert the function to a Colmena task
-            function = convert_to_colmena_method(method)
+            function = convert_to_colmena_method(function)
             name = function.name
 
             # If the function is not an executable, submit it as a single task

--- a/colmena/task_server/tests/test_parsl.py
+++ b/colmena/task_server/tests/test_parsl.py
@@ -59,7 +59,7 @@ def store(tmpdir):
 @fixture(autouse=True)
 def server_and_queue(config, store) -> Tuple[ParslTaskServer, ColmenaQueues]:
     queues = PipeQueues(proxystore_name='store', proxystore_threshold=5000, serialization_method='pickle')
-    server = ParslTaskServer([f, capitalize, bad_task, EchoTask(), FakeMPITask(), count_nodes], queues, config)
+    server = ParslTaskServer([(f, {'executors': 'all'}), capitalize, bad_task, EchoTask(), FakeMPITask(), count_nodes], queues, config)
     yield server, queues
     if server.is_alive():
         queues.send_kill_signal()


### PR DESCRIPTION
Was not handling functions with executor options correctly in ParslTaskServer