### PR TITLE
Migrate Colmena to Pydantic V2

### DIFF
--- a/colmena/models/results.py
+++ b/colmena/models/results.py
@@ -12,7 +12,7 @@ from traceback import TracebackException
 from typing import Any, Tuple, Dict, Optional, Union, List, Sequence
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, Extra
+from pydantic import BaseModel, ConfigDict, Field
 from proxystore.proxy import Proxy
 
 from colmena.proxy import get_store, store_proxy_stats
@@ -132,10 +132,12 @@ class FailureInformation(BaseModel):
         return cls(exception=repr(exc), traceback="".join(tb.format()))
 
 
-class WorkerInformation(BaseModel, extra=Extra.allow):
+class WorkerInformation(BaseModel):
     """Information about the worker that executed this task"""
 
     hostname: Optional[str] = Field(None, description='Hostname of the worker who executed this task')
+
+    model_config = ConfigDict(extra='allow')
 
 
 class ResourceRequirements(BaseModel):
@@ -216,14 +218,14 @@ class Result(BaseModel):
     task_info: Optional[Dict[str, Any]] = Field(default_factory=dict,
                                                 description="Task tracking information to be transmitted "
                                                             "along with inputs and results. User provided")
-    resources: ResourceRequirements = Field(default_factory=ResourceRequirements, help='List of the resources required for a task, if desired')
+    resources: ResourceRequirements = Field(default_factory=ResourceRequirements, description='List of the resources required for a task, if desired')
     failure_info: Optional[FailureInformation] = Field(None, description="Messages about task failure. Provided by Task Server")
     worker_info: Optional[WorkerInformation] = Field(None, description="Information about the worker which executed a task. Provided by Task Server")
     message_sizes: Dict[str, int] = Field(default_factory=dict, description='Sizes of the inputs and results in bytes')
 
     # Timings
-    timestamp: Timestamps = Field(default_factory=Timestamps, help='Times at which major events occurred')
-    time: TimeSpans = Field(default_factory=TimeSpans, help='Elapsed time between major events')
+    timestamp: Timestamps = Field(default_factory=Timestamps, description='Times at which major events occurred')
+    time: TimeSpans = Field(default_factory=TimeSpans, description='Elapsed time between major events')
 
     # Serialization options
     serialization_method: SerializationMethod = Field(SerializationMethod.JSON,
@@ -284,7 +286,7 @@ class Result(BaseModel):
             kwargs['exclude'] = {'inputs', 'value'}
 
         # Use pydantic's encoding for everything except `inputs` and `values`
-        data = super().dict(**kwargs)
+        data = self.model_dump(**kwargs)
 
         # Add inputs/values back to data unless the user excluded them
         if isinstance(user_exclude, set):

--- a/colmena/models/results.py
+++ b/colmena/models/results.py
@@ -15,8 +15,7 @@ from uuid import uuid4
 from pydantic import BaseModel, ConfigDict, Field
 from proxystore.proxy import Proxy
 
-from colmena.proxy import get_store, store_proxy_stats
-from colmena.proxy import proxy_json_encoder
+from colmena.proxy import get_store, store_proxy_stats, StoreConfig, proxy_json_encoder
 
 logger = logging.getLogger(__name__)
 
@@ -233,7 +232,7 @@ class Result(BaseModel):
     keep_inputs: bool = Field(True, description="Whether to keep the inputs with the result object or delete "
                                                 "them after the method has completed")
     proxystore_name: Optional[str] = Field(None, description="Name of ProxyStore backend you use for transferring large objects")
-    proxystore_config: Optional[Dict] = Field(None, description="ProxyStore backend configuration")
+    proxystore_config: Optional[StoreConfig] = Field(None, description="ProxyStore backend configuration")
     proxystore_threshold: Optional[int] = Field(None,
                                                 description="Proxy all input/output objects larger than this threshold in bytes")
 

--- a/colmena/proxy.py
+++ b/colmena/proxy.py
@@ -1,6 +1,7 @@
 """Utilities for interacting with ProxyStore"""
 import logging
 import warnings
+from typing import Dict
 
 import proxystore
 from proxystore.proxy import extract
@@ -10,6 +11,14 @@ from proxystore.store.base import Store
 from proxystore.store.utils import resolve_async, get_key
 
 from typing import Any, Dict, Union, List, Optional
+
+proxystore_version = tuple(int(v) for v in proxystore.__version__.split('.'))
+if proxystore_version >= (0, 7, 0):
+    # In ProxyStore v0.7 and later, the Store config is a pydantic model.
+    from proxystore.store.config import StoreConfig
+else:
+    # In ProxyStore v0.6 and older, the Store config is a dictionary.
+    StoreConfig = Dict
 
 logger = logging.getLogger(__name__)
 

--- a/colmena/queue/base.py
+++ b/colmena/queue/base.py
@@ -162,7 +162,7 @@ class ColmenaQueues:
         logger.debug(f'Received value: {str(message)[:25]}')
 
         # Parse the value and mark it as complete
-        result_obj = Result.parse_raw(message)
+        result_obj = Result.model_validate_json(message)
         result_obj.time.deserialize_results = result_obj.deserialize()
         result_obj.mark_result_received()
 
@@ -278,7 +278,7 @@ class ColmenaQueues:
         logger.debug(f'Received a task message with topic {topic} inbound queue')
 
         # Get the message
-        task = Result.parse_raw(message)
+        task = Result.model_validate_json(message)
         task.mark_input_received()
         return topic, task
 

--- a/colmena/queue/tests/test_base.py
+++ b/colmena/queue/tests/test_base.py
@@ -167,8 +167,6 @@ def test_event_count(queue):
 
     # Sent the task back
     task.set_result(1)
-    print(queue._active_tasks)
-    print(task)
     queue.send_result(task)
     queue.get_result()
     assert queue.active_count == 0

--- a/colmena/task_server/tests/test_globus.py
+++ b/colmena/task_server/tests/test_globus.py
@@ -41,7 +41,7 @@ class FakeExecutor:
         new_future.set_result(result)
         return new_future
 
-    def shutdown(self):
+    def shutdown(self, *args, **kwargs):
         pass
 
 

--- a/colmena/task_server/tests/test_parsl.py
+++ b/colmena/task_server/tests/test_parsl.py
@@ -39,7 +39,7 @@ def count_nodes(x, _resources: ResourceRequirements):
 def config(tmpdir):
     return Config(
         executors=[
-            HighThroughputExecutor(max_workers=1, address='127.0.0.1')
+            HighThroughputExecutor(max_workers_per_node=1, address='127.0.0.1')
         ],
         strategy=None,
         run_dir=str(tmpdir / 'run'),

--- a/colmena/tests/test_proxy.py
+++ b/colmena/tests/test_proxy.py
@@ -11,6 +11,7 @@ from proxystore.connectors.local import LocalConnector
 
 from colmena.proxy import get_store
 from colmena.proxy import proxy_json_encoder
+from colmena.proxy import ProxyJSONSerializationWarning
 from colmena.proxy import resolve_proxies_async
 
 
@@ -46,7 +47,8 @@ def test_get_store_initialize_from_config() -> None:
 
 def test_proxy_json_encoder() -> None:
     p = Proxy(lambda: 'test-value')
-    result = json.dumps({'proxy': p}, default=proxy_json_encoder)
+    with pytest.warns(ProxyJSONSerializationWarning):
+        result = json.dumps({'proxy': p}, default=proxy_json_encoder)
     reconstructed_data = json.loads(result)
     assert 'proxy' in reconstructed_data
 

--- a/colmena/thinker/tests/test_thinker.py
+++ b/colmena/thinker/tests/test_thinker.py
@@ -135,6 +135,10 @@ def test_logger_timings_process(queues, caplog):
     thinker = TestThinker(queues, daemon=True)
     thinker.start()
 
+    # Thinker sets queue roles to "client". Switch back to "any" role
+    # since we use methods intended for the "server" role in the test.
+    queues.set_role("any")
+
     # Spoof a result completing
     queues.send_inputs(1, method='test')
     topic, result = queues.get_task()
@@ -175,6 +179,10 @@ def test_run(queues):
     rec = ResourceCounter(1, ["event"])
     rec.acquire(None, 1)
     th = ExampleThinker(queues, rec, flag, daemon=True)
+
+    # Thinker sets queue roles to "client". Switch back to "any" role
+    # since we use methods intended for the "server" role in the test.
+    queues.set_role("any")
 
     # Launch it and wait for it to run
     th.start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "parsl>=2022",
-    "pydantic==1.*",
+    "pydantic>=2,<3",
     "redis>=4.3",
     "proxystore>=0.5.0,<0.7.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "parsl>=2022",
     "pydantic>=2,<3",
     "redis>=4.3",
-    "proxystore>=0.5.0,<0.7.0"
+    "proxystore>=0.5.0,<0.8.0"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Fixes #118 by upgrading Colmena to Pydantic V2. The upgrade is pretty simple, just changing some method names and how extra arguments are allowed.

Upgrading to Pydantic V2 also allows Colmena to support ProxyStore v0.7 so I increased the maximum support ProxyStore version. This required a couple extra lines of code to have a backwards compatible annotation for `Result.proxystore_config`.

While I was at it, I fixed all of the various warnings in the test suite, and fixed an error in the queues serialization test. There were no changes to public code, and you can take a look at the second and third commits to see exactly what I fixed.