### PR TITLE
Remove upper bound on ProxyStore versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "parsl>=2022",
     "pydantic>=2,<3",
     "redis>=4.3",
-    "proxystore>=0.5.0,<0.8.0"
+    "proxystore>=0.5.0"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
The ProxyStore APIs relevant to Colmena have been stable for a while now, and I don't have any plans to make any breaking changes there. I think its safe now to remove the upper bound. This should make version solving easier which is likely to be a more common frustration for users than any highly unlikely breaking changes to the ProxyStore core API.