### PR TITLE
Auto-evict automatic proxies on read

### DIFF
--- a/colmena/models/results.py
+++ b/colmena/models/results.py
@@ -371,7 +371,7 @@ class Result(BaseModel):
         else:
             store = None
 
-        def _serialize_and_proxy(value, evict=False) -> Tuple[str, int]:
+        def _serialize_and_proxy(value, evict=True) -> Tuple[str, int]:
             """Helper function for serializing and proxying
 
             Args:

--- a/colmena/models/results.py
+++ b/colmena/models/results.py
@@ -252,7 +252,7 @@ class Result(BaseModel):
 
     @classmethod
     def from_args_and_kwargs(cls, fn_args: Sequence[Any], fn_kwargs: Dict[str, Any] = None, **kwargs):
-        """Create a result object form a the arguments and kwargs for the function
+        """Create a result object from the arguments and kwargs for the function
 
         Keyword arguments to this function are passed to the initializer for `Result`.
 

--- a/colmena/tests/conftest.py
+++ b/colmena/tests/conftest.py
@@ -1,0 +1,14 @@
+from tempfile import TemporaryDirectory
+
+from proxystore.connectors.file import FileConnector
+from proxystore.store import Store, register_store, unregister_store
+from pytest import fixture
+
+
+@fixture
+def store(tmp_path):
+    with TemporaryDirectory() as tmpdir:
+        with Store('store', FileConnector(tmpdir), metrics=True) as store:
+            register_store(store)
+            yield store
+            unregister_store(store)

--- a/colmena/tests/test_model.py
+++ b/colmena/tests/test_model.py
@@ -1,6 +1,11 @@
 """Tests for the data models"""
 import sys
 
+from proxystore.connectors.local import LocalConnector
+from proxystore.proxy import Proxy
+from proxystore.store import Store
+from proxystore.store.utils import get_key
+
 from colmena.models import ResourceRequirements, Result
 
 
@@ -28,3 +33,22 @@ def test_message_sizes():
     result.serialize()
     assert result.message_sizes['inputs'] >= 2 * sys.getsizeof('0' * 8)
     assert result.message_sizes['inputs'] >= sys.getsizeof(1)
+
+
+def test_proxy():
+    with Store('store', connector=LocalConnector()) as store:
+        result = Result.from_args_and_kwargs(
+            ('a' * 1000,),
+            serialization_method='pickle',
+            proxystore_name='store',
+            proxystore_threshold=10,
+            proxystore_config=store.config()
+        )
+        result.serialize()
+        result.deserialize()
+        assert isinstance(result.inputs[0][0], Proxy)
+        proxy = result.inputs[0][0]
+        key = get_key(proxy)
+
+        assert len(result.args[0]) == 1000
+        assert store.exists(key)

--- a/colmena/tests/test_model.py
+++ b/colmena/tests/test_model.py
@@ -1,9 +1,7 @@
 """Tests for the data models"""
 import sys
 
-from proxystore.connectors.local import LocalConnector
 from proxystore.proxy import Proxy
-from proxystore.store import Store
 from proxystore.store.utils import get_key
 
 from colmena.models import ResourceRequirements, Result
@@ -35,20 +33,19 @@ def test_message_sizes():
     assert result.message_sizes['inputs'] >= sys.getsizeof(1)
 
 
-def test_proxy():
-    with Store('store', connector=LocalConnector()) as store:
-        result = Result.from_args_and_kwargs(
-            ('a' * 1000,),
-            serialization_method='pickle',
-            proxystore_name='store',
-            proxystore_threshold=10,
-            proxystore_config=store.config()
-        )
-        result.serialize()
-        result.deserialize()
-        assert isinstance(result.inputs[0][0], Proxy)
-        proxy = result.inputs[0][0]
-        key = get_key(proxy)
+def test_proxy(store):
+    result = Result.from_args_and_kwargs(
+        ('a' * 1000,),
+        serialization_method='pickle',
+        proxystore_name='store',
+        proxystore_threshold=10,
+        proxystore_config=store.config()
+    )
+    result.serialize()
+    result.deserialize()
+    assert isinstance(result.inputs[0][0], Proxy)
+    proxy = result.inputs[0][0]
+    key = get_key(proxy)
 
-        assert len(result.args[0]) == 1000
-        assert store.exists(key)
+    assert len(result.args[0]) == 1000
+    assert store.exists(key)

--- a/colmena/tests/test_model.py
+++ b/colmena/tests/test_model.py
@@ -48,4 +48,4 @@ def test_proxy(store):
     key = get_key(proxy)
 
     assert len(result.args[0]) == 1000
-    assert store.exists(key)
+    assert not store.exists(key)

--- a/colmena/tests/test_task_model.py
+++ b/colmena/tests/test_task_model.py
@@ -4,10 +4,6 @@ from pathlib import Path
 from math import isnan
 
 from pytest import fixture, mark
-from proxystore.connectors.file import FileConnector
-from proxystore.store import Store
-from proxystore.store import register_store
-from proxystore.store import unregister_store
 
 from colmena.models.methods import ExecutableMethod, PythonMethod, PythonGeneratorMethod
 from colmena.models import ResourceRequirements, Result, SerializationMethod
@@ -31,14 +27,6 @@ def result() -> Result:
     result = Result.from_args_and_kwargs((1,), method='echo')
     result.serialize()
     return result
-
-
-@fixture
-def store(tmpdir):
-    with Store('store', FileConnector(tmpdir), metrics=True) as store:
-        register_store(store)
-        yield store
-        unregister_store(store)
 
 
 def echo(x: Any) -> Any:
@@ -78,7 +66,7 @@ def test_generator(result):
     result = task(result)
     assert result.success, result.failure_info.traceback
     result.deserialize()
-    assert result.value == [0,]
+    assert result.value == [0, ]
 
 
 def test_generator_with_return(result):
@@ -88,7 +76,7 @@ def test_generator_with_return(result):
     result = task(result)
     assert result.success, result.failure_info.traceback
     result.deserialize()
-    assert result.value == [[0,], 'done']
+    assert result.value == [[0, ], 'done']
 
 
 @mark.parametrize('return_value', [True, False])


### PR DESCRIPTION
Evicts proxies of inputs made automatically during serialization as soon as they are read on a worker. It'll be better to wait for the task to complete (so that a failed task can be restarted and still read the data), but this is a first start.

See discussion #136 